### PR TITLE
Revert sonar-pitest-plugin to version 0.8 as version 0.9 does not show mutation analysis

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,8 +100,8 @@ sonarqube_plugins_sonar67:
     version: "1.6.0.2388"
     baseurl: "https://sonarsource.bintray.com/Distribution/sonar-typescript-plugin"
   - name: "sonar-pitest-plugin"
-    version: "0.9"
-    baseurl: "https://github.com/VinodAnandan/sonar-pitest/releases/download/v0.9"
+    version: "0.8" # Stick to old verison as 0.9 does not show "mutation analysis" data
+    baseurl: "https://github.com/VinodAnandan/sonar-pitest/releases/download/v0.8"
   - name: "sonar-github-plugin"
     version: "1.4.2.1027"
     baseurl: "https://sonarsource.bintray.com/Distribution/sonar-github-plugin"


### PR DESCRIPTION
Bug reported in https://github.com/VinodAnandan/sonar-pitest/issues/29
We attempted a downgrade of sonar-pitest-plugin from 0.9 to 0.8 and it works ok with version 0.8
The mutation analysis data are displayed after the downgrade of the plugin to 0.8 (with SQ-6.7.4)